### PR TITLE
Vanilla Furniture Expanded Research Patch For Fur Beds

### DIFF
--- a/1.3/Patches/FurniturePatch.xml
+++ b/1.3/Patches/FurniturePatch.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd"> 
+					<xpath>/Defs/ThingDef[defName="VFEV_FurBed"]</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_BasicFurniture</li>
+						</researchPrerequisites>		
+					</value>
+				</li>
+				<li Class="PatchOperationAdd"> 
+					<xpath>/Defs/ThingDef[defName="VFEV_DoubleFurBed"]</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_BasicFurniture</li>
+						</researchPrerequisites>		
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Patch to require "Basic Furniture" research from Vanilla Furniture Expanded on the Fur Beds if present.